### PR TITLE
Unify buyer and seller into single user role

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -328,10 +328,9 @@ def register():
     if not email or not username or not password:
         return jsonify({'error': 'Email, username, and password are required'}), 400
 
-    role = 'user'  # all new accounts are buyer/seller by default
+    role = 'user'  # unified role - all users can buy, sell, and trade
 
-    # Admins are auto-approved, buyers/sellers need admin approval
-    status = 'approved' if role == 'admin' else 'pending'
+    status = 'pending'  # new accounts require admin approval
 
     # Hash password
     password_hash = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -80,11 +80,11 @@ async function login(email, password) {
 }
 
 // Register
-async function register(email, username, password, role) {
+async function register(email, username, password) {
     const response = await fetch(API_URL + '/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, username, password, role })
+        body: JSON.stringify({ email, username, password })
     });
 
     const data = await response.json();

--- a/frontend/pages/auth/login.html
+++ b/frontend/pages/auth/login.html
@@ -199,8 +199,6 @@
         errorEl.classList.add('warning');
         errorEl.textContent = 'Your account is pending admin approval. You can browse listings but cannot buy, sell, or trade yet.';
         errorEl.style.display = 'block';
-      } else if (result.user.role === 'seller') {
-        window.location.href = '/pages/seller/dashboard.html';
       } else {
         window.location.href = '/pages/buyer/browse.html';
       }

--- a/frontend/pages/auth/register.html
+++ b/frontend/pages/auth/register.html
@@ -144,7 +144,7 @@
 
   <div class="auth-card">
     <h2>Sign Up</h2>
-    <p class="subtitle">Fill in your details to get started</p>
+    <p class="subtitle">One account to buy, sell, and trade</p>
 
     <div class="auth-error" id="errorMessage"></div>
     <div class="auth-success" id="successMessage"></div>
@@ -169,15 +169,6 @@
       <div class="auth-field">
         <label for="confirmPassword">Confirm Password</label>
         <input type="password" id="confirmPassword" placeholder="Re-enter your password" required>
-      </div>
-
-      <div class="auth-field">
-        <label for="role">Account Type</label>
-        <select id="role" required>
-          <option value="user">Buyer</option>
-          <option value="seller">Seller</option>
-        </select>
-        <p class="field-hint">Buyer and Seller accounts require admin approval</p>
       </div>
 
       <button type="submit" class="btn-signup">Sign Up</button>
@@ -223,15 +214,13 @@
       return;
     }
 
-    var role = document.getElementById('role').value;
-
-    var result = await register(email, username, password, role);
+    var result = await register(email, username, password);
 
     if (result.success) {
       if (result.user.role === 'admin') {
         window.location.href = '/pages/admin/dashboard.html';
       } else {
-        document.getElementById('successMessage').textContent = 'Account created! Your account is pending admin approval. You can browse listings but cannot buy, sell, or trade until approved.';
+        document.getElementById('successMessage').textContent = 'Account created! Your account is pending admin approval. Once approved, you can buy, sell, and trade on Switchr.';
         document.getElementById('successMessage').style.display = 'block';
         document.getElementById('registerForm').style.display = 'none';
       }

--- a/frontend/pages/buyer/browse.html
+++ b/frontend/pages/buyer/browse.html
@@ -354,12 +354,10 @@
   if (isLoggedIn()) {
     var user = getUser();
     var links = '';
-    if (user && user.role === 'seller') {
-      links += '<a href="/pages/seller/dashboard.html">Seller Dashboard</a>';
-    }
     if (user && user.role === 'admin') {
       links += '<a href="/pages/admin/dashboard.html">Admin Dashboard</a>';
     }
+    links += '<a href="/pages/seller/dashboard.html">My Listings</a>';
     links += '<a href="#" onclick="logout()">Logout</a>';
     authLinks.innerHTML = links;
   } else {

--- a/frontend/pages/buyer/cart.html
+++ b/frontend/pages/buyer/cart.html
@@ -168,12 +168,10 @@
 
   var authLinks = document.getElementById('authLinks');
   var cartLinks = '';
-  if (user && user.role === 'seller') {
-    cartLinks += '<a href="/pages/seller/dashboard.html">Seller Dashboard</a>';
-  }
   if (user && user.role === 'admin') {
     cartLinks += '<a href="/pages/admin/dashboard.html">Admin Dashboard</a>';
   }
+  cartLinks += '<a href="/pages/seller/dashboard.html">My Listings</a>';
   cartLinks += '<a href="#" onclick="logout()">Logout</a>';
   authLinks.innerHTML = cartLinks;
 

--- a/frontend/pages/buyer/checkout.html
+++ b/frontend/pages/buyer/checkout.html
@@ -337,12 +337,10 @@
 
   var authLinks = document.getElementById('authLinks');
   var checkoutLinks = '';
-  if (user && user.role === 'seller') {
-    checkoutLinks += '<a href="/pages/seller/dashboard.html">Seller Dashboard</a>';
-  }
   if (user && user.role === 'admin') {
     checkoutLinks += '<a href="/pages/admin/dashboard.html">Admin Dashboard</a>';
   }
+  checkoutLinks += '<a href="/pages/seller/dashboard.html">My Listings</a>';
   checkoutLinks += '<a href="#" onclick="logout()">Logout</a>';
   authLinks.innerHTML = checkoutLinks;
 

--- a/frontend/pages/buyer/compare.html
+++ b/frontend/pages/buyer/compare.html
@@ -141,12 +141,10 @@
   if (isLoggedIn()) {
     var user = getUser();
     var links = '';
-    if (user && user.role === 'seller') {
-      links += '<a href="/pages/seller/dashboard.html">Seller Dashboard</a>';
-    }
     if (user && user.role === 'admin') {
       links += '<a href="/pages/admin/dashboard.html">Admin Dashboard</a>';
     }
+    links += '<a href="/pages/seller/dashboard.html">My Listings</a>';
     links += '<a href="#" onclick="logout()">Logout</a>';
     authLinks.innerHTML = links;
   } else {

--- a/frontend/pages/buyer/invoice.html
+++ b/frontend/pages/buyer/invoice.html
@@ -140,12 +140,10 @@
 
   var authLinks = document.getElementById('authLinks');
   var links = '';
-  if (user && user.role === 'seller') {
-    links += '<a href="/pages/seller/dashboard.html">Seller Dashboard</a>';
-  }
   if (user && user.role === 'admin') {
     links += '<a href="/pages/admin/dashboard.html">Admin Dashboard</a>';
   }
+  links += '<a href="/pages/seller/dashboard.html">My Listings</a>';
   links += '<a href="#" onclick="logout()">Logout</a>';
   authLinks.innerHTML = links;
 

--- a/frontend/pages/buyer/listing.html
+++ b/frontend/pages/buyer/listing.html
@@ -195,12 +195,10 @@
   if (isLoggedIn()) {
     var user = getUser();
     var links = '';
-    if (user && user.role === 'seller') {
-      links += '<a href="/pages/seller/dashboard.html">Seller Dashboard</a>';
-    }
     if (user && user.role === 'admin') {
       links += '<a href="/pages/admin/dashboard.html">Admin Dashboard</a>';
     }
+    links += '<a href="/pages/seller/dashboard.html">My Listings</a>';
     links += '<a href="#" onclick="logout()">Logout</a>';
     authLinks.innerHTML = links;
   } else {

--- a/frontend/pages/buyer/purchases.html
+++ b/frontend/pages/buyer/purchases.html
@@ -120,12 +120,10 @@
 
   var authLinks = document.getElementById('authLinks');
   var links = '';
-  if (user && user.role === 'seller') {
-    links += '<a href="/pages/seller/dashboard.html">Seller Dashboard</a>';
-  }
   if (user && user.role === 'admin') {
     links += '<a href="/pages/admin/dashboard.html">Admin Dashboard</a>';
   }
+  links += '<a href="/pages/seller/dashboard.html">My Listings</a>';
   links += '<a href="#" onclick="logout()">Logout</a>';
   authLinks.innerHTML = links;
 

--- a/frontend/pages/offers/offers.html
+++ b/frontend/pages/offers/offers.html
@@ -167,12 +167,10 @@
   if (isLoggedIn()) {
     var user = getUser();
     var links = '';
-    if (user && user.role === 'seller') {
-      links += '<a href="/pages/seller/dashboard.html">Seller Dashboard</a>';
-    }
     if (user && user.role === 'admin') {
       links += '<a href="/pages/admin/dashboard.html">Admin Dashboard</a>';
     }
+    links += '<a href="/pages/seller/dashboard.html">My Listings</a>';
     links += '<a href="#" onclick="logout()">Logout</a>';
     authLinks.innerHTML = links;
   }

--- a/frontend/pages/profile.html
+++ b/frontend/pages/profile.html
@@ -248,21 +248,17 @@
   // Nav auth links
   var authLinks = document.getElementById('authLinks');
   var navLinks = '';
-  if (user && user.role === 'seller') {
-    navLinks += '<a href="/pages/seller/dashboard.html">Seller Dashboard</a>';
-  }
   if (user && user.role === 'admin') {
     navLinks += '<a href="/pages/admin/dashboard.html">Admin Dashboard</a>';
   }
+  navLinks += '<a href="/pages/seller/dashboard.html">My Listings</a>';
   navLinks += '<a href="#" onclick="logout()">Logout</a>';
   authLinks.innerHTML = navLinks;
 
-  // Seller quick links
-  if (user && user.role === 'seller') {
-    document.getElementById('sellerLinks').innerHTML =
-      '<a href="/pages/seller/dashboard.html" class="btn" style="margin-right:8px;">Seller Dashboard</a>' +
-      '<a href="/pages/seller/sales.html" class="btn">My Sales</a>';
-  }
+  // Quick links to listings and sales
+  document.getElementById('sellerLinks').innerHTML =
+    '<a href="/pages/seller/dashboard.html" class="btn" style="margin-right:8px;">My Listings</a>' +
+    '<a href="/pages/seller/sales.html" class="btn">My Sales</a>';
 
   // Load profile from API
   fetch('/api/auth/me', {


### PR DESCRIPTION
## Summary
- Removed the buyer/seller account type dropdown from registration — all users sign up with one unified role
- Every logged-in user can now buy, sell, and trade without needing a separate account type
- "Seller Dashboard" nav link renamed to "My Listings" and shown for all users, not just those with a seller role

## Changes
- **register.html** — removed account type select, updated messaging
- **auth.js** — removed role parameter from register function
- **login.html** — removed seller-specific redirect after login
- **app.py** — cleaned up backend comment on role assignment
- **All nav bars** (browse, cart, checkout, compare, invoice, listing, purchases, offers, profile) — replaced `role === 'seller'` gate with always-visible "My Listings" link