### PR TITLE
Add token-based password reset flow

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -262,6 +262,16 @@ def init_db():
         )
     ''')
     cur.execute('''
+        CREATE TABLE IF NOT EXISTS password_resets (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+            token VARCHAR(64) UNIQUE NOT NULL,
+            expires_at TIMESTAMP NOT NULL,
+            used_at TIMESTAMP,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+    cur.execute('''
         ALTER TABLE listings ALTER COLUMN status SET DEFAULT 'PENDING_APPROVAL'
     ''')
     conn.close()
@@ -468,6 +478,75 @@ def login():
             'denial_reason': user.get('denial_reason')
         }
     })
+
+
+@app.route('/api/auth/forgot-password', methods=['POST'])
+def forgot_password():
+    data = request.get_json() or {}
+    email = (data.get('email') or '').strip().lower()
+
+    response = {'ok': True, 'message': 'If that email is registered, a reset link has been generated.'}
+
+    if not email:
+        return jsonify(response)
+
+    conn = get_db()
+    cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+    cur.execute('SELECT id FROM users WHERE LOWER(email) = %s', (email,))
+    user = cur.fetchone()
+
+    if user:
+        token = uuid.uuid4().hex
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+        cur.execute(
+            'INSERT INTO password_resets (user_id, token, expires_at) VALUES (%s, %s, %s)',
+            (user['id'], token, expires_at)
+        )
+        # In dev/coursework mode, surface the link directly so the demo works without SMTP.
+        if os.getenv('FLASK_ENV', 'development') != 'production':
+            response['reset_link'] = '/pages/auth/reset-password.html?token=' + token
+            response['token'] = token
+
+    conn.close()
+    return jsonify(response)
+
+
+@app.route('/api/auth/reset-password', methods=['POST'])
+def reset_password():
+    data = request.get_json() or {}
+    token = (data.get('token') or '').strip()
+    new_password = data.get('new_password') or ''
+
+    if not token or not new_password:
+        return jsonify({'error': 'Token and new password are required'}), 400
+    if len(new_password) < 6:
+        return jsonify({'error': 'Password must be at least 6 characters'}), 400
+
+    conn = get_db()
+    cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+    cur.execute(
+        'SELECT id, user_id, expires_at, used_at FROM password_resets WHERE token = %s',
+        (token,)
+    )
+    reset = cur.fetchone()
+
+    if not reset or reset['used_at'] is not None:
+        conn.close()
+        return jsonify({'error': 'Invalid or expired reset link'}), 400
+
+    expires_at = reset['expires_at']
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    if expires_at < datetime.now(timezone.utc):
+        conn.close()
+        return jsonify({'error': 'Invalid or expired reset link'}), 400
+
+    password_hash = bcrypt.hashpw(new_password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
+    cur.execute('UPDATE users SET password_hash = %s WHERE id = %s', (password_hash, reset['user_id']))
+    cur.execute('UPDATE password_resets SET used_at = CURRENT_TIMESTAMP WHERE id = %s', (reset['id'],))
+    conn.close()
+
+    return jsonify({'ok': True, 'message': 'Password updated. You can now log in.'})
 
 
 @app.route('/api/auth/me', methods=['GET'])

--- a/backend/app.py
+++ b/backend/app.py
@@ -410,6 +410,8 @@ def register():
 
     if not email or not username or not password:
         return jsonify({'error': 'Email, username, and password are required'}), 400
+    if len(password) < 8:
+        return jsonify({'error': 'Password must be at least 8 characters'}), 400
 
     role = 'user'  # unified role - all users can buy, sell, and trade
 
@@ -519,8 +521,8 @@ def reset_password():
 
     if not token or not new_password:
         return jsonify({'error': 'Token and new password are required'}), 400
-    if len(new_password) < 6:
-        return jsonify({'error': 'Password must be at least 6 characters'}), 400
+    if len(new_password) < 8:
+        return jsonify({'error': 'Password must be at least 8 characters'}), 400
 
     conn = get_db()
     cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,6 +1,19 @@
 """
-Switchr - Database Seed Script
-Clears all tables and populates with sample data for development and testing.
+Switchr - Demo Seed Script
+
+Wipes the database and populates it for the live demo.
+
+Logged-into accounts:
+  Admin: admin@switchr.com / Admin123!
+  Demo:  demo@switchr.com  / Password123!
+
+Silent ghost users (never logged into during the demo, exist only as the
+counterparty for demo's seeded sales/purchases/reviews/offers/bids):
+  taylor@switchr.com
+  jordan@switchr.com
+
+The third demoable account is registered live during the demo so the
+register -> admin approval -> first purchase flow can be shown end-to-end.
 """
 
 import psycopg2
@@ -13,10 +26,12 @@ load_dotenv()
 
 DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql://admin@localhost:5432/switchr')
 
+
 def get_db():
     conn = psycopg2.connect(DATABASE_URL)
     conn.autocommit = True
     return conn
+
 
 def hash_password(password):
     return bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
@@ -27,196 +42,358 @@ def seed():
     cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
 
     print("Clearing existing data...")
+    # Order matters: children before parents
+    cur.execute("DELETE FROM password_resets")
+    cur.execute("DELETE FROM bids")
+    cur.execute("DELETE FROM reviews")
+    cur.execute("DELETE FROM trades")
+    cur.execute("DELETE FROM wishlist")
     cur.execute("DELETE FROM notifications")
     cur.execute("DELETE FROM order_items")
     cur.execute("DELETE FROM orders")
     cur.execute("DELETE FROM transactions")
     cur.execute("DELETE FROM cart")
-    cur.execute("DELETE FROM trades")
     cur.execute("DELETE FROM listings")
     cur.execute("DELETE FROM users")
 
     # Reset sequences
-    cur.execute("ALTER SEQUENCE users_id_seq RESTART WITH 1")
-    cur.execute("ALTER SEQUENCE listings_id_seq RESTART WITH 1")
-    cur.execute("ALTER SEQUENCE orders_id_seq RESTART WITH 1")
-    cur.execute("ALTER SEQUENCE order_items_id_seq RESTART WITH 1")
-    cur.execute("ALTER SEQUENCE notifications_id_seq RESTART WITH 1")
-    cur.execute("ALTER SEQUENCE transactions_id_seq RESTART WITH 1")
-    cur.execute("ALTER SEQUENCE trades_id_seq RESTART WITH 1")
+    for seq in [
+        'users_id_seq', 'listings_id_seq', 'orders_id_seq', 'order_items_id_seq',
+        'notifications_id_seq', 'transactions_id_seq', 'trades_id_seq',
+        'reviews_id_seq', 'bids_id_seq', 'wishlist_id_seq', 'cart_id_seq',
+    ]:
+        try:
+            cur.execute(f"ALTER SEQUENCE {seq} RESTART WITH 1")
+        except psycopg2.Error:
+            pass  # sequence may not exist yet on a fresh DB
 
     print("Creating users...")
 
-    # Admin
     cur.execute('''
         INSERT INTO users (email, username, password_hash, role, status)
         VALUES (%s, %s, %s, %s, %s) RETURNING id
     ''', ('admin@switchr.com', 'admin', hash_password('Admin123!'), 'admin', 'approved'))
     admin_id = cur.fetchone()['id']
 
-    # Sellers
-    cur.execute('''
-        INSERT INTO users (email, username, password_hash, role, status)
-        VALUES (%s, %s, %s, %s, %s) RETURNING id
-    ''', ('seller1@switchr.com', 'techseller', hash_password('Seller123!'), 'user', 'approved'))
-    seller1_id = cur.fetchone()['id']
-
-    cur.execute('''
-        INSERT INTO users (email, username, password_hash, role, status)
-        VALUES (%s, %s, %s, %s, %s) RETURNING id
-    ''', ('seller2@switchr.com', 'gadgetguru', hash_password('Seller123!'), 'user', 'approved'))
-    seller2_id = cur.fetchone()['id']
-
-    # Buyers
     cur.execute('''
         INSERT INTO users (email, username, password_hash, role, status, balance)
         VALUES (%s, %s, %s, %s, %s, %s) RETURNING id
-    ''', ('buyer1@switchr.com', 'techbuyer', hash_password('Buyer123!'), 'user', 'approved', 1000.00))
-    buyer1_id = cur.fetchone()['id']
+    ''', ('demo@switchr.com', 'demo', hash_password('Password123!'), 'user', 'approved', 1500.00))
+    demo_id = cur.fetchone()['id']
 
     cur.execute('''
         INSERT INTO users (email, username, password_hash, role, status, balance)
         VALUES (%s, %s, %s, %s, %s, %s) RETURNING id
-    ''', ('buyer2@switchr.com', 'gadgetfan', hash_password('Buyer123!'), 'user', 'approved', 1000.00))
-    buyer2_id = cur.fetchone()['id']
-
-    # Pending user (waiting for admin approval)
-    cur.execute('''
-        INSERT INTO users (email, username, password_hash, role, status)
-        VALUES (%s, %s, %s, %s, %s) RETURNING id
-    ''', ('pending@switchr.com', 'newuser', hash_password('User123!'), 'user', 'pending'))
-
-    # Active listings - seller 1
-    cur.execute('''
-        INSERT INTO listings (seller_id, title, description, category, price, condition, listing_type, status, quantity, photo_urls)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id
-    ''', (seller1_id, 'iPhone 14 Pro 256GB', 'Excellent condition, barely used. Space Black. Comes with original box and charger.', 'Phones', 750.00, 'LIKE_NEW', 'BOTH', 'ACTIVE', 1,
-        ['https://images.unsplash.com/photo-1678685888221-cda773a3dcdb?w=400']))
-    listing1_id = cur.fetchone()['id']
+    ''', ('taylor@switchr.com', 'taylor', hash_password('NotForLogin'), 'user', 'approved', 200.00))
+    taylor_id = cur.fetchone()['id']
 
     cur.execute('''
-        INSERT INTO listings (seller_id, title, description, category, price, condition, listing_type, status, quantity, photo_urls)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id
-    ''', (seller1_id, 'MacBook Air M2 13"', '8GB RAM, 256GB SSD. Midnight color. Used for college, great condition.', 'Laptops', 950.00, 'GOOD', 'SALE', 'ACTIVE', 1,
-        ['https://images.unsplash.com/photo-1517336714731-489689fd1ca8?w=400']))
-    listing2_id = cur.fetchone()['id']
+        INSERT INTO users (email, username, password_hash, role, status, balance)
+        VALUES (%s, %s, %s, %s, %s, %s) RETURNING id
+    ''', ('jordan@switchr.com', 'jordan', hash_password('NotForLogin'), 'user', 'approved', 200.00))
+    jordan_id = cur.fetchone()['id']
+
+    print("Creating demo's active listings...")
+
+    def insert_listing(seller_id, title, desc, category, price, condition,
+                       listing_type, status='ACTIVE', quantity=1, photos=None,
+                       starting_price=None, auction_duration_days=None,
+                       auction_end_offset_hours=None):
+        cur.execute('''
+            INSERT INTO listings (
+                seller_id, title, description, category, price, condition,
+                listing_type, status, quantity, photo_urls,
+                starting_price, auction_duration_days,
+                auction_end_time
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                      CASE WHEN %s IS NOT NULL
+                           THEN CURRENT_TIMESTAMP + (%s || ' hours')::INTERVAL
+                           ELSE NULL END)
+            RETURNING id
+        ''', (
+            seller_id, title, desc, category, price, condition,
+            listing_type, status, quantity, photos or [],
+            starting_price, auction_duration_days,
+            auction_end_offset_hours, str(auction_end_offset_hours) if auction_end_offset_hours else None,
+        ))
+        return cur.fetchone()['id']
+
+    iphone_id = insert_listing(
+        demo_id, 'iPhone 15 Pro 256GB',
+        'Natural Titanium. Battery health 100%. Includes original box, USB-C cable, and a clear case.',
+        'Phones', 850.00, 'LIKE_NEW', 'SALE',
+        photos=['https://images.unsplash.com/photo-1696446702183-be9605d4209e?w=400']
+    )
+
+    macbook_id = insert_listing(
+        demo_id, 'MacBook Pro 14" M3',
+        '16GB unified memory, 512GB SSD. Space Black. Light use, no scratches. AppleCare+ until 2026.',
+        'Laptops', 1400.00, 'LIKE_NEW', 'BOTH',
+        photos=['https://images.unsplash.com/photo-1517336714731-489689fd1ca8?w=400']
+    )
+
+    airpods_id = insert_listing(
+        demo_id, 'AirPods Pro (2nd Gen)',
+        'USB-C MagSafe case. Active Noise Cancellation works perfectly. Replaced ear tips included.',
+        'Headphones', 180.00, 'GOOD', 'SALE',
+        photos=['https://images.unsplash.com/photo-1606841837239-c5a1a4a07af7?w=400']
+    )
+
+    ipad_id = insert_listing(
+        demo_id, 'iPad Air M2 11"',
+        '128GB, Blue, WiFi. Used for note-taking. Screen protector applied since day one.',
+        'Tablets', 400.00, 'LIKE_NEW', 'TRADE',
+        photos=['https://images.unsplash.com/photo-1544244015-0df4b3ffc6b0?w=400']
+    )
+
+    watch_id = insert_listing(
+        demo_id, 'Apple Watch Series 9 45mm',
+        'GPS, Midnight Aluminum. Sport Band included. Some micro-scratches on case from daily wear.',
+        'Other', 300.00, 'GOOD', 'BOTH',
+        photos=['https://images.unsplash.com/photo-1546868871-7041f2a55e12?w=400']
+    )
+
+    sony_id = insert_listing(
+        demo_id, 'Sony WH-1000XM5',
+        'Industry-leading noise cancellation. Black. Carry case and all original cables included.',
+        'Headphones', 250.00, 'LIKE_NEW', 'SALE',
+        photos=['https://images.unsplash.com/photo-1546435770-a3e426bf472b?w=400']
+    )
+
+    mouse_id = insert_listing(
+        demo_id, 'Logitech MX Master 3S',
+        'Wireless ergonomic mouse. Quiet click. USB-C charging. Two available.',
+        'Other', 80.00, 'LIKE_NEW', 'SALE', quantity=2,
+        photos=['https://images.unsplash.com/photo-1527814050087-3793815479db?w=400']
+    )
+
+    print("Creating demo's auction (3-day duration, with seeded bids)...")
+
+    auction_id = insert_listing(
+        demo_id, 'Nintendo Switch OLED + 3 games',
+        'White OLED model, dock and Joy-Cons included. Bundle: Mario Kart, Zelda TOTK, Smash Ultimate.',
+        'Other', 200.00, 'LIKE_NEW', 'AUCTION',
+        starting_price=200.00, auction_duration_days=3, auction_end_offset_hours=72,
+        photos=['https://images.unsplash.com/photo-1578303512597-81e6cc155b3e?w=400']
+    )
+    cur.execute('INSERT INTO bids (listing_id, bidder_id, amount) VALUES (%s, %s, %s)',
+                (auction_id, taylor_id, 210.00))
+    cur.execute('INSERT INTO bids (listing_id, bidder_id, amount) VALUES (%s, %s, %s)',
+                (auction_id, jordan_id, 235.00))
+    cur.execute('INSERT INTO bids (listing_id, bidder_id, amount) VALUES (%s, %s, %s)',
+                (auction_id, taylor_id, 250.00))
+
+    print("Creating demo's pending-approval listing (admin will approve live)...")
+
+    insert_listing(
+        demo_id, 'Google Pixel 8 Pro 128GB',
+        'Obsidian. Selling because upgrading. Excellent camera, no scratches.',
+        'Phones', 600.00, 'LIKE_NEW', 'SALE', status='PENDING_APPROVAL',
+        photos=['https://images.unsplash.com/photo-1598327105666-5b89351aff97?w=400']
+    )
+
+    print("Creating demo's already-sold listings...")
+
+    sold_iphone_id = insert_listing(
+        demo_id, 'iPhone 13 Mini 128GB',
+        'Blue. Replaced battery in late 2024. Minor screen scratch, otherwise great.',
+        'Phones', 380.00, 'GOOD', 'SALE', status='SOLD', quantity=0,
+        photos=['https://images.unsplash.com/photo-1632661674596-df8be070a5c5?w=400']
+    )
+
+    sold_pencil_id = insert_listing(
+        demo_id, 'Apple Pencil 2nd Gen',
+        'Works perfectly. Tip slightly worn from use, charges via MagSafe.',
+        'Other', 80.00, 'GOOD', 'SALE', status='SOLD', quantity=0,
+        photos=['https://images.unsplash.com/photo-1583394838336-acd977736f90?w=400']
+    )
+
+    print("Creating ghost listings (so demo has things to browse/buy/wishlist)...")
+
+    steamdeck_id = insert_listing(
+        taylor_id, 'Steam Deck OLED 512GB',
+        'Excellent condition, hardly used. Carry case and dock included.',
+        'Other', 480.00, 'LIKE_NEW', 'BOTH',
+        photos=['https://images.unsplash.com/photo-1640955014216-75201056c829?w=400']
+    )
+
+    gameboy_id = insert_listing(
+        taylor_id, 'Vintage Game Boy DMG-01',
+        'Original 1989 Game Boy. Screen has typical retro lines. Comes with Tetris cartridge.',
+        'Other', 120.00, 'FAIR', 'SALE',
+        photos=['https://images.unsplash.com/photo-1531525645387-7f14be1bdbbd?w=400']
+    )
+
+    # Listing taylor "sold" to demo in the past (status SOLD)
+    taylor_old_sale_id = insert_listing(
+        taylor_id, 'Anker Soundcore Liberty 4',
+        'Wireless earbuds with ANC. Charging case included.',
+        'Headphones', 90.00, 'GOOD', 'SALE', status='SOLD', quantity=0,
+        photos=['https://images.unsplash.com/photo-1590658268037-6bf12165a8df?w=400']
+    )
+
+    gopro_id = insert_listing(
+        jordan_id, 'GoPro HERO12 Black',
+        '5.3K video. Two batteries, dual charger, and 64GB SD card included.',
+        'Other', 300.00, 'LIKE_NEW', 'SALE',
+        photos=['https://images.unsplash.com/photo-1623788858432-4a8db35b9c5e?w=400']
+    )
+
+    drone_id = insert_listing(
+        jordan_id, 'DJI Mini 3 Drone',
+        'Sub-249g, 4K HDR. Two batteries, ND filter pack, and shoulder bag.',
+        'Other', 450.00, 'LIKE_NEW', 'TRADE',
+        photos=['https://images.unsplash.com/photo-1473968512647-3e447244af8f?w=400']
+    )
+
+    # Listing jordan "sold" to demo in the past
+    jordan_old_sale_id = insert_listing(
+        jordan_id, 'USB-C Hub 7-in-1',
+        'HDMI, SD, microSD, USB-A x2, USB-C PD, ethernet.',
+        'Chargers', 35.00, 'LIKE_NEW', 'SALE', status='SOLD', quantity=0,
+        photos=['https://images.unsplash.com/photo-1625948515291-69613efd103f?w=400']
+    )
+
+    print("Creating demo's past sales (taylor and jordan bought from demo)...")
+
+    def create_completed_purchase(buyer_id, seller_id, listing_id, title, price,
+                                  ship_first, ship_last, ship_city, ship_state):
+        cur.execute('''
+            INSERT INTO orders (
+                buyer_id, subtotal, tax_rate, tax_amount, total,
+                ship_first_name, ship_last_name, ship_address,
+                ship_city, ship_state, ship_zip,
+                bill_same_as_ship, card_last_four, status,
+                created_at
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                      CURRENT_TIMESTAMP - INTERVAL '7 days')
+            RETURNING id
+        ''', (
+            buyer_id, price, 0.08, round(float(price) * 0.08, 2), round(float(price) * 1.08, 2),
+            ship_first, ship_last, '101 Demo Street',
+            ship_city, ship_state, '39759',
+            True, '4242', 'COMPLETED'
+        ))
+        order_id = cur.fetchone()['id']
+
+        cur.execute('''
+            INSERT INTO order_items (order_id, listing_id, title, price, seller_id, created_at)
+            VALUES (%s, %s, %s, %s, %s, CURRENT_TIMESTAMP - INTERVAL '7 days')
+        ''', (order_id, listing_id, title, price, seller_id))
+
+        cur.execute('''
+            INSERT INTO transactions (buyer_id, seller_id, listing_id, title, price, payment_method, status, created_at)
+            VALUES (%s, %s, %s, %s, %s, %s, 'COMPLETED', CURRENT_TIMESTAMP - INTERVAL '7 days')
+            RETURNING id
+        ''', (buyer_id, seller_id, listing_id, title, price, 'balance'))
+        return cur.fetchone()['id']
+
+    # demo sold "iPhone 13 Mini" to taylor 7 days ago
+    sale_to_taylor_txn = create_completed_purchase(
+        taylor_id, demo_id, sold_iphone_id, 'iPhone 13 Mini 128GB', 380.00,
+        'Taylor', 'Reed', 'Memphis', 'TN'
+    )
+
+    # demo sold "Apple Pencil" to jordan 4 days ago
+    sale_to_jordan_txn = create_completed_purchase(
+        jordan_id, demo_id, sold_pencil_id, 'Apple Pencil 2nd Gen', 80.00,
+        'Jordan', 'Hayes', 'Atlanta', 'GA'
+    )
+
+    print("Creating demo's past purchases (demo bought from taylor and jordan)...")
+
+    # demo bought from taylor (will be REVIEWED by demo)
+    purchase_from_taylor_txn = create_completed_purchase(
+        demo_id, taylor_id, taylor_old_sale_id, 'Anker Soundcore Liberty 4', 90.00,
+        'Demo', 'User', 'Starkville', 'MS'
+    )
+
+    # demo bought from jordan (will be UNREVIEWED so live demo can show "Leave Review")
+    purchase_from_jordan_txn = create_completed_purchase(
+        demo_id, jordan_id, jordan_old_sale_id, 'USB-C Hub 7-in-1', 35.00,
+        'Demo', 'User', 'Starkville', 'MS'
+    )
+
+    print("Creating reviews...")
 
     cur.execute('''
-        INSERT INTO listings (seller_id, title, description, category, price, condition, listing_type, status, quantity, photo_urls)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-    ''', (seller1_id, 'AirPods Pro 2nd Gen', 'Active Noise Cancellation, MagSafe charging case. Minor ear tip wear, works perfectly.', 'Headphones', 180.00, 'GOOD', 'SALE', 'ACTIVE', 1,
-        ['https://images.unsplash.com/photo-1606841837239-c5a1a4a07af7?w=400']))
+        INSERT INTO reviews (transaction_id, buyer_id, seller_id, rating, comment, created_at)
+        VALUES (%s, %s, %s, %s, %s, CURRENT_TIMESTAMP - INTERVAL '5 days')
+    ''', (sale_to_taylor_txn, taylor_id, demo_id, 5,
+          'Phone arrived faster than expected and was exactly as described. Would buy from again!'))
 
     cur.execute('''
-        INSERT INTO listings (seller_id, title, description, category, price, condition, listing_type, status, quantity, photo_urls)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-    ''', (seller1_id, 'iPad Air 5th Gen WiFi', '64GB, Blue. Used for drawing and note taking. Screen protector applied from day one.', 'Tablets', 420.00, 'LIKE_NEW', 'TRADE', 'ACTIVE', 1,
-        ['https://images.unsplash.com/photo-1544244015-0df4b3ffc6b0?w=400']))
+        INSERT INTO reviews (transaction_id, buyer_id, seller_id, rating, comment, created_at)
+        VALUES (%s, %s, %s, %s, %s, CURRENT_TIMESTAMP - INTERVAL '2 days')
+    ''', (sale_to_jordan_txn, jordan_id, demo_id, 4,
+          'Great packaging and quick shipping. Tip wear was a bit more than I expected but still works.'))
 
-    # Active listings - seller 2
+    # demo's review of taylor's old sale
     cur.execute('''
-        INSERT INTO listings (seller_id, title, description, category, price, condition, listing_type, status, quantity, photo_urls)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id
-    ''', (seller2_id, 'Samsung Galaxy S23 Ultra', '256GB Phantom Black. S Pen included. Screen in perfect condition, no cracks.', 'Phones', 680.00, 'LIKE_NEW', 'BOTH', 'ACTIVE', 1,
-        ['https://images.unsplash.com/photo-1610945415295-d9bbf067e59c?w=400']))
-    listing5_id = cur.fetchone()['id']
+        INSERT INTO reviews (transaction_id, buyer_id, seller_id, rating, comment, created_at)
+        VALUES (%s, %s, %s, %s, %s, CURRENT_TIMESTAMP - INTERVAL '4 days')
+    ''', (purchase_from_taylor_txn, demo_id, taylor_id, 5,
+          'Earbuds in great shape, sound quality is excellent.'))
 
+    print("Creating trade offers (badge will light up for demo)...")
+
+    # jordan -> demo (incoming, PENDING — drives offers_pending count)
     cur.execute('''
-        INSERT INTO listings (seller_id, title, description, category, price, condition, listing_type, status, quantity, photo_urls)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-    ''', (seller2_id, 'Dell XPS 15 Laptop', 'Intel i7, 16GB RAM, 512GB SSD. Some scuffs on lid but screen is pristine.', 'Laptops', 820.00, 'GOOD', 'SALE', 'ACTIVE', 1,
-        ['https://images.unsplash.com/photo-1593642632559-0c6d3fc62b89?w=400']))
+        INSERT INTO trades (sender_id, receiver_id, offered_listing_id, wanted_listing_id, cash_offer, status)
+        VALUES (%s, %s, %s, %s, %s, 'PENDING')
+    ''', (jordan_id, demo_id, drone_id, ipad_id, 50.00))
 
+    # demo -> taylor (outgoing, PENDING)
     cur.execute('''
-        INSERT INTO listings (seller_id, title, description, category, price, condition, listing_type, status, quantity, photo_urls)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-    ''', (seller2_id, 'Sony WH-1000XM5 Headphones', 'Industry-leading noise cancellation. Comes with carry case and all accessories.', 'Headphones', 220.00, 'LIKE_NEW', 'SALE', 'ACTIVE', 1,
-        ['https://images.unsplash.com/photo-1546435770-a3e426bf472b?w=400']))
+        INSERT INTO trades (sender_id, receiver_id, offered_listing_id, wanted_listing_id, cash_offer, status)
+        VALUES (%s, %s, %s, %s, %s, 'PENDING')
+    ''', (demo_id, taylor_id, watch_id, steamdeck_id, 100.00))
 
-    cur.execute('''
-        INSERT INTO listings (seller_id, title, description, category, price, condition, listing_type, status, quantity, photo_urls)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-    ''', (seller2_id, 'Apple 67W USB-C Charger', 'Original Apple charger, works perfectly. Cable has slight wear near connector.', 'Chargers', 35.00, 'GOOD', 'SALE', 'ACTIVE', 2,
-        ['https://images.unsplash.com/photo-1583863788434-e58a36330cf0?w=400']))
+    print("Creating wishlist entries for demo...")
 
-    # Pending approval listings
-    cur.execute('''
-        INSERT INTO listings (seller_id, title, description, category, price, condition, listing_type, status, quantity, photo_urls)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-    ''', (seller1_id, 'Google Pixel 8 Pro', '128GB Obsidian. Amazing camera system. Selling because upgrading.', 'Phones', 600.00, 'LIKE_NEW', 'SALE', 'PENDING_APPROVAL', 1,
-        ['https://images.unsplash.com/photo-1598327105666-5b89351aff97?w=400']))
+    cur.execute('INSERT INTO wishlist (user_id, listing_id) VALUES (%s, %s)', (demo_id, gopro_id))
+    cur.execute('INSERT INTO wishlist (user_id, listing_id) VALUES (%s, %s)', (demo_id, steamdeck_id))
+    cur.execute('INSERT INTO wishlist (user_id, listing_id) VALUES (%s, %s)', (demo_id, gameboy_id))
 
-    cur.execute('''
-        INSERT INTO listings (seller_id, title, description, category, price, condition, listing_type, status, quantity, photo_urls)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-    ''', (seller2_id, 'Nintendo Switch OLED', 'White version, barely used. Comes with dock, joycons, and 3 games.', 'Other', 280.00, 'LIKE_NEW', 'BOTH', 'PENDING_APPROVAL', 1,
-        ['https://images.unsplash.com/photo-1578303512597-81e6cc155b3e?w=400']))
+    print("Creating notifications for demo (mix of read/unread)...")
 
-    # Sold listing
-    cur.execute('''
-        INSERT INTO listings (seller_id, title, description, category, price, condition, listing_type, status, quantity, photo_urls)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id
-    ''', (seller1_id, 'iPhone 13 Mini', '128GB, Blue. Screen has minor scratch but works great.', 'Phones', 380.00, 'GOOD', 'SALE', 'SOLD', 1,
-        ['https://images.unsplash.com/photo-1632661674596-df8be070a5c5?w=400']))
-    sold_listing_id = cur.fetchone()['id']
-
-    print("Creating sample order...")
-
-    # Sample completed order
-    cur.execute('''
-        INSERT INTO orders (
-            buyer_id, subtotal, tax_rate, tax_amount, total,
-            ship_first_name, ship_last_name, ship_address, ship_city, ship_state, ship_zip,
-            bill_same_as_ship, card_last_four, status
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-        RETURNING id
-    ''', (
-        buyer1_id, 380.00, 0.08, 30.40, 410.40,
-        'John', 'Doe', '123 Tech Street', 'Starkville', 'MS', '39759',
-        True, '4242', 'COMPLETED'
-    ))
-    order_id = cur.fetchone()['id']
-
-    cur.execute('''
-        INSERT INTO order_items (order_id, listing_id, title, price, seller_id)
-        VALUES (%s, %s, %s, %s, %s)
-    ''', (order_id, sold_listing_id, 'iPhone 13 Mini', 380.00, seller1_id))
-
-    print("Creating sample notifications...")
-
-    cur.execute('''
-        INSERT INTO notifications (user_id, message, type, is_read)
-        VALUES (%s, %s, %s, %s)
-    ''', (seller1_id, f'Your item "iPhone 13 Mini" was purchased by techbuyer! Order #{order_id}', 'SALE', False))
-
-    cur.execute('''
-        INSERT INTO notifications (user_id, message, type, is_read)
-        VALUES (%s, %s, %s, %s)
-    ''', (seller1_id, 'Your listing "Google Pixel 8 Pro" is pending admin approval.', 'INFO', True))
-
-    cur.execute('''
-        INSERT INTO notifications (user_id, message, type, is_read)
-        VALUES (%s, %s, %s, %s)
-    ''', (seller2_id, 'Your listing "Nintendo Switch OLED" is pending admin approval.', 'INFO', False))
+    notifications = [
+        (demo_id, 'Welcome to Switchr! Your seller account is approved.', 'INFO', True),
+        (demo_id, 'Your listing "iPhone 13 Mini 128GB" was purchased by taylor.', 'SALE', True),
+        (demo_id, 'taylor left you a 5-star review on "iPhone 13 Mini 128GB".', 'REVIEW', True),
+        (demo_id, 'Your listing "Apple Pencil 2nd Gen" was purchased by jordan.', 'SALE', False),
+        (demo_id, 'jordan left you a 4-star review on "Apple Pencil 2nd Gen".', 'REVIEW', False),
+        (demo_id, 'jordan sent you a trade offer on "iPad Air M2 11"".', 'OFFER', False),
+        (demo_id, 'Your listing "Google Pixel 8 Pro 128GB" is pending admin approval.', 'INFO', True),
+        (demo_id, 'New bid on "Nintendo Switch OLED + 3 games": $250 by taylor.', 'BID', False),
+    ]
+    for uid, msg, typ, is_read in notifications:
+        cur.execute('''
+            INSERT INTO notifications (user_id, message, type, is_read)
+            VALUES (%s, %s, %s, %s)
+        ''', (uid, msg, typ, is_read))
 
     conn.close()
 
-    print("\n Seed complete! Here's your test data:\n")
-    print("USERS")
-    print("  Admin:   admin@switchr.com     / Admin123!")
-    print("  Seller1: seller1@switchr.com   / Seller123!  (username: techseller)")
-    print("  Seller2: seller2@switchr.com   / Seller123!  (username: gadgetguru)")
-    print("  Buyer1:  buyer1@switchr.com    / Buyer123!   (username: techbuyer)")
-    print("  Buyer2:  buyer2@switchr.com    / Buyer123!   (username: gadgetfan)")
-    print("  Pending: pending@switchr.com   / User123!    (status: pending)")
-    print("\nLISTINGS")
-    print("  8 ACTIVE listings (4 per seller)")
-    print("  2 PENDING_APPROVAL listings")
-    print("  1 SOLD listing")
-    print("\nORDERS")
-    print("  1 completed order (techbuyer bought iPhone 13 Mini)")
-    print("\nNOTIFICATIONS")
-    print("  3 sample notifications")
+    print("\n" + "=" * 60)
+    print("Seed complete. Demo accounts:")
+    print("=" * 60)
+    print("  Admin: admin@switchr.com / Admin123!")
+    print("  Demo:  demo@switchr.com  / Password123!")
+    print()
+    print("Silent ghost users (do not log in during demo):")
+    print("  taylor@switchr.com, jordan@switchr.com")
+    print()
+    print("Demo account is ready with:")
+    print("  - 7 active listings (mix of SALE/TRADE/BOTH)")
+    print("  - 1 active auction with 3 seeded bids (ends in ~3 days)")
+    print("  - 1 listing PENDING_APPROVAL (approve live with admin)")
+    print("  - 2 past sales w/ buyer reviews + 2 past purchases (1 reviewed, 1 not)")
+    print("  - 1 incoming trade offer (badge lights up)")
+    print("  - 1 outgoing trade offer")
+    print("  - 3 wishlist items, 8 notifications")
+    print("  - $1500 balance")
+
 
 if __name__ == '__main__':
     confirm = input("This will DELETE all existing data. Type 'yes' to continue: ")

--- a/frontend/pages/admin/approvals.html
+++ b/frontend/pages/admin/approvals.html
@@ -9,9 +9,12 @@
         (function() {
             var token = localStorage.getItem('token');
             var user = JSON.parse(localStorage.getItem('user') || '{}');
-            if (!token || !user || user.role !== 'admin') {
+            if (!token) {
                 document.documentElement.style.visibility = 'hidden';
                 window.location.href = '/pages/auth/login.html';
+            } else if (!user || user.role !== 'admin') {
+                document.documentElement.style.visibility = 'hidden';
+                window.location.href = '/pages/buyer/browse.html';
             }
         })();
     </script>

--- a/frontend/pages/admin/dashboard.html
+++ b/frontend/pages/admin/dashboard.html
@@ -9,9 +9,12 @@
         (function() {
             var token = localStorage.getItem('token');
             var user = JSON.parse(localStorage.getItem('user') || '{}');
-            if (!token || !user || user.role !== 'admin') {
+            if (!token) {
                 document.documentElement.style.visibility = 'hidden';
                 window.location.href = '/pages/auth/login.html';
+            } else if (!user || user.role !== 'admin') {
+                document.documentElement.style.visibility = 'hidden';
+                window.location.href = '/pages/buyer/browse.html';
             }
         })();
     </script>

--- a/frontend/pages/auth/forgot-password.html
+++ b/frontend/pages/auth/forgot-password.html
@@ -3,10 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Switchr - Login</title>
+  <title>Switchr - Forgot Password</title>
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=Syne:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../../css/shared.css">
-  <script src="../../js/auth.js"></script>
   <style>
     .main { max-width: 420px; }
 
@@ -74,11 +73,12 @@
     }
 
     .btn-login:hover { background: #333; }
+    .btn-login:disabled { background: #999; cursor: not-allowed; }
 
-    .auth-error {
-      background: #fce4ec;
-      color: #c62828;
-      border: 1px solid #ef9a9a;
+    .auth-banner {
+      background: #e6f4ea;
+      color: #2d7a3a;
+      border: 1px solid #b6e0c2;
       border-radius: 4px;
       padding: 10px 14px;
       margin-bottom: 16px;
@@ -86,10 +86,20 @@
       display: none;
     }
 
-    .auth-error.warning {
-      background: #fff3e0;
-      color: #b36200;
-      border-color: #ffe0b2;
+    .dev-link-box {
+      margin-top: 12px;
+      padding: 10px 12px;
+      background: #fff8e1;
+      border: 1px dashed #f0c040;
+      border-radius: 4px;
+      font-size: 12px;
+      color: #6b5500;
+      word-break: break-all;
+    }
+
+    .dev-link-box a {
+      color: #1a1a1a;
+      font-weight: 600;
     }
 
     .auth-links {
@@ -107,16 +117,6 @@
     }
 
     .auth-links a:hover { text-decoration: underline; }
-
-    .forgot-link {
-      display: block;
-      margin-top: 12px;
-      font-size: 12px;
-      color: #888;
-      text-decoration: none;
-    }
-
-    .forgot-link:hover { color: #1a1a1a; }
   </style>
 </head>
 <body>
@@ -125,36 +125,30 @@
 <script src="/js/nav.js"></script>
 
 <div class="header-bar">
-  <h1>Welcome Back</h1>
-  <p class="meta">Sign in to your Switchr account</p>
+  <h1>Forgot Password</h1>
+  <p class="meta">We'll generate a reset link for your account</p>
 </div>
 
 <div class="main">
 
   <div class="auth-card">
-    <h2>Login</h2>
-    <p class="subtitle">Enter your credentials to continue</p>
+    <h2>Reset your password</h2>
+    <p class="subtitle">Enter the email associated with your account</p>
 
-    <div class="auth-error" id="errorMessage"></div>
+    <div class="auth-banner" id="successBanner"></div>
+    <div id="devLinkBox"></div>
 
-    <form id="loginForm" onsubmit="handleLogin(event)">
+    <form id="forgotForm" onsubmit="handleSubmit(event)">
       <div class="auth-field">
         <label for="email">Email</label>
         <input type="email" id="email" placeholder="you@example.com" required>
       </div>
 
-      <div class="auth-field">
-        <label for="password">Password</label>
-        <input type="password" id="password" placeholder="Enter your password" required>
-      </div>
-
-      <button type="submit" class="btn-login">Login</button>
+      <button type="submit" class="btn-login" id="submitBtn">Send reset link</button>
     </form>
 
-    <a href="/pages/auth/forgot-password.html" class="forgot-link">Forgot your password?</a>
-
     <div class="auth-links">
-      <p>Don't have an account? <a href="/pages/auth/register.html">Sign Up</a></p>
+      <p><a href="/pages/auth/login.html">&larr; Back to login</a></p>
     </div>
   </div>
 
@@ -164,41 +158,46 @@
   <a href="/pages/terms.html">Terms</a>
   <a href="/pages/privacy.html">Privacy</a>
   <a href="#">Help</a>
-  <p style="margin-top:8px;">Switchr &mdash; Sprint 3 &mdash; CSE 4214</p>
+  <p style="margin-top:8px;">Switchr &mdash; Sprint 4 &mdash; CSE 4214</p>
 </footer>
 
 <script>
-  redirectIfLoggedIn();
-
-  async function handleLogin(event) {
+  function handleSubmit(event) {
     event.preventDefault();
+    var email = document.getElementById('email').value.trim();
+    var btn = document.getElementById('submitBtn');
+    var banner = document.getElementById('successBanner');
+    var devBox = document.getElementById('devLinkBox');
 
-    var email = document.getElementById('email').value;
-    var password = document.getElementById('password').value;
-    var errorEl = document.getElementById('errorMessage');
+    btn.disabled = true;
+    btn.textContent = 'Working...';
+    devBox.innerHTML = '';
 
-    errorEl.style.display = 'none';
-    errorEl.classList.remove('warning');
+    fetch('/api/auth/forgot-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: email })
+    })
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      banner.textContent = data.message || 'If that email is registered, a reset link has been generated.';
+      banner.style.display = 'block';
 
-    var result = await login(email, password);
-
-    if (result.success) {
-      if (result.user.role === 'admin') {
-        window.location.href = '/pages/admin/dashboard.html';
-      } else if (result.user.status === 'denied') {
-        errorEl.textContent = 'Your account has been denied.';
-        errorEl.style.display = 'block';
-      } else if (result.user.status === 'pending') {
-        errorEl.classList.add('warning');
-        errorEl.textContent = 'Your account is pending admin approval. You can browse listings but cannot buy, sell, or trade yet.';
-        errorEl.style.display = 'block';
-      } else {
-        window.location.href = '/pages/buyer/browse.html';
+      if (data.reset_link) {
+        devBox.innerHTML = '<div class="dev-link-box"><strong>Dev mode:</strong> '
+          + 'No email is sent in this build. Use this reset link directly:<br><br>'
+          + '<a href="' + data.reset_link + '">' + data.reset_link + '</a></div>';
       }
-    } else {
-      errorEl.textContent = result.error;
-      errorEl.style.display = 'block';
-    }
+
+      btn.disabled = false;
+      btn.textContent = 'Send reset link';
+    })
+    .catch(function() {
+      banner.textContent = 'Network error. Check that the backend is running.';
+      banner.style.display = 'block';
+      btn.disabled = false;
+      btn.textContent = 'Send reset link';
+    });
   }
 </script>
 

--- a/frontend/pages/auth/reset-password.html
+++ b/frontend/pages/auth/reset-password.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Switchr - Reset Password</title>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600&family=Syne:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../css/shared.css">
+  <style>
+    .main { max-width: 420px; }
+
+    .auth-card {
+      background: white;
+      border: 1px solid #e0e0e0;
+      border-radius: 6px;
+      padding: 32px;
+    }
+
+    .auth-card h2 {
+      font-family: 'Syne', sans-serif;
+      font-size: 22px;
+      margin-bottom: 6px;
+    }
+
+    .auth-card .subtitle {
+      font-size: 13px;
+      color: #888;
+      margin-bottom: 24px;
+    }
+
+    .auth-field { margin-bottom: 18px; }
+
+    .auth-field label {
+      display: block;
+      font-size: 12px;
+      font-weight: 600;
+      color: #555;
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+      margin-bottom: 6px;
+    }
+
+    .auth-field input {
+      width: 100%;
+      padding: 10px 12px;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      font-size: 14px;
+      font-family: 'DM Sans', sans-serif;
+      background: #fafaf8;
+      color: #1a1a1a;
+    }
+
+    .auth-field input:focus {
+      outline: none;
+      border-color: #1a1a1a;
+      background: white;
+    }
+
+    .btn-login {
+      display: block;
+      width: 100%;
+      padding: 12px;
+      background: #1a1a1a;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      font-size: 15px;
+      font-family: 'DM Sans', sans-serif;
+      font-weight: 600;
+      cursor: pointer;
+      margin-top: 4px;
+    }
+
+    .btn-login:hover { background: #333; }
+    .btn-login:disabled { background: #999; cursor: not-allowed; }
+
+    .auth-error {
+      background: #fce4ec;
+      color: #c62828;
+      border: 1px solid #ef9a9a;
+      border-radius: 4px;
+      padding: 10px 14px;
+      margin-bottom: 16px;
+      font-size: 13px;
+      display: none;
+    }
+
+    .auth-banner {
+      background: #e6f4ea;
+      color: #2d7a3a;
+      border: 1px solid #b6e0c2;
+      border-radius: 4px;
+      padding: 10px 14px;
+      margin-bottom: 16px;
+      font-size: 13px;
+      display: none;
+    }
+
+    .auth-links {
+      margin-top: 20px;
+      padding-top: 16px;
+      border-top: 1px solid #f0f0f0;
+      font-size: 13px;
+      color: #888;
+    }
+
+    .auth-links a {
+      color: #1a1a1a;
+      font-weight: 500;
+      text-decoration: none;
+    }
+
+    .auth-links a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+
+<div id="nav-root"></div>
+<script src="/js/nav.js"></script>
+
+<div class="header-bar">
+  <h1>Reset Password</h1>
+  <p class="meta">Choose a new password for your account</p>
+</div>
+
+<div class="main">
+
+  <div class="auth-card">
+    <h2>New password</h2>
+    <p class="subtitle">Must be at least 6 characters</p>
+
+    <div class="auth-error" id="errorBanner"></div>
+    <div class="auth-banner" id="successBanner"></div>
+
+    <form id="resetForm" onsubmit="handleSubmit(event)">
+      <div class="auth-field">
+        <label for="newPassword">New password</label>
+        <input type="password" id="newPassword" placeholder="At least 6 characters" required minlength="6">
+      </div>
+
+      <div class="auth-field">
+        <label for="confirmPassword">Confirm password</label>
+        <input type="password" id="confirmPassword" placeholder="Re-enter new password" required minlength="6">
+      </div>
+
+      <button type="submit" class="btn-login" id="submitBtn">Update password</button>
+    </form>
+
+    <div class="auth-links">
+      <p><a href="/pages/auth/login.html">&larr; Back to login</a></p>
+    </div>
+  </div>
+
+</div>
+
+<footer>
+  <a href="/pages/terms.html">Terms</a>
+  <a href="/pages/privacy.html">Privacy</a>
+  <a href="#">Help</a>
+  <p style="margin-top:8px;">Switchr &mdash; Sprint 4 &mdash; CSE 4214</p>
+</footer>
+
+<script>
+  var token = new URLSearchParams(window.location.search).get('token');
+
+  if (!token) {
+    var err = document.getElementById('errorBanner');
+    err.textContent = 'Missing reset token. Use the link from the forgot-password page.';
+    err.style.display = 'block';
+    document.getElementById('submitBtn').disabled = true;
+  }
+
+  function showError(msg) {
+    var el = document.getElementById('errorBanner');
+    el.textContent = msg;
+    el.style.display = 'block';
+    document.getElementById('successBanner').style.display = 'none';
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    var newPw = document.getElementById('newPassword').value;
+    var confirmPw = document.getElementById('confirmPassword').value;
+
+    if (newPw !== confirmPw) {
+      showError('Passwords do not match.');
+      return;
+    }
+
+    var btn = document.getElementById('submitBtn');
+    btn.disabled = true;
+    btn.textContent = 'Updating...';
+
+    fetch('/api/auth/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: token, new_password: newPw })
+    })
+    .then(function(r) { return r.json().then(function(d) { return { ok: r.ok, body: d }; }); })
+    .then(function(res) {
+      if (!res.ok) {
+        showError(res.body.error || 'Could not reset password.');
+        btn.disabled = false;
+        btn.textContent = 'Update password';
+        return;
+      }
+      var banner = document.getElementById('successBanner');
+      banner.textContent = res.body.message || 'Password updated. Redirecting to login...';
+      banner.style.display = 'block';
+      document.getElementById('errorBanner').style.display = 'none';
+      setTimeout(function() { window.location.href = '/pages/auth/login.html'; }, 1500);
+    })
+    .catch(function() {
+      showError('Network error. Check that the backend is running.');
+      btn.disabled = false;
+      btn.textContent = 'Update password';
+    });
+  }
+</script>
+
+</body>
+</html>

--- a/frontend/pages/auth/reset-password.html
+++ b/frontend/pages/auth/reset-password.html
@@ -128,7 +128,7 @@
 
   <div class="auth-card">
     <h2>New password</h2>
-    <p class="subtitle">Must be at least 6 characters</p>
+    <p class="subtitle">Must be at least 8 characters</p>
 
     <div class="auth-error" id="errorBanner"></div>
     <div class="auth-banner" id="successBanner"></div>
@@ -136,12 +136,12 @@
     <form id="resetForm" onsubmit="handleSubmit(event)">
       <div class="auth-field">
         <label for="newPassword">New password</label>
-        <input type="password" id="newPassword" placeholder="At least 6 characters" required minlength="6">
+        <input type="password" id="newPassword" placeholder="At least 8 characters" required minlength="8">
       </div>
 
       <div class="auth-field">
         <label for="confirmPassword">Confirm password</label>
-        <input type="password" id="confirmPassword" placeholder="Re-enter new password" required minlength="6">
+        <input type="password" id="confirmPassword" placeholder="Re-enter new password" required minlength="8">
       </div>
 
       <button type="submit" class="btn-login" id="submitBtn">Update password</button>

--- a/frontend/pages/buyer/checkout.html
+++ b/frontend/pages/buyer/checkout.html
@@ -290,7 +290,7 @@
             <span>Total</span>
             <span id="total">$0.00</span>
           </div>
-          <button class="btn-confirm" onclick="confirmTransaction()">Confirm Transaction</button>
+          <button class="btn-confirm" id="confirmBtn" onclick="confirmTransaction()">Confirm Transaction</button>
           <p class="notice">This is a simulated transaction. No real payment is processed. (REQ-87)</p>
         </div>
       </div>
@@ -381,6 +381,10 @@
       return;
     }
 
+    var btn = document.getElementById('confirmBtn');
+    btn.disabled = true;
+    btn.textContent = 'Processing...';
+
     var payload = {
       firstName: firstName, lastName: lastName, address: address, city: city, state: state, zip: zip,
       cardNumber: cardNumber, billSameAsShip: billSame
@@ -412,9 +416,15 @@
           '<p style="color:#555;margin-top:8px;">Order #' + data.order_id + ' | Total: $' + data.total + '</p>';
       } else {
         alert(data.error || 'Something went wrong.');
+        btn.disabled = false;
+        btn.textContent = 'Confirm Transaction';
       }
     })
-    .catch(function() { alert('Could not complete purchase. Try again.'); });
+    .catch(function() {
+      alert('Could not complete purchase. Try again.');
+      btn.disabled = false;
+      btn.textContent = 'Confirm Transaction';
+    });
   }
 
   function logout() {

--- a/frontend/pages/buyer/listing.html
+++ b/frontend/pages/buyer/listing.html
@@ -299,8 +299,6 @@
       }
     }
 
-    html += '<button class="btn" onclick="alert(\'Messaging coming soon!\')">Message Seller</button>';
-    html += '<button class="btn danger" onclick="alert(\'Report flow coming soon!\')">Report Listing</button>';
     html += '</div>';
     html += '</div>';
 

--- a/frontend/pages/buyer/listing.html
+++ b/frontend/pages/buyer/listing.html
@@ -19,22 +19,91 @@
     .listing-left { flex: 1; }
     .listing-right { width: 320px; }
 
-    .photo-placeholder {
-      display: flex;
-      gap: 10px;
-    }
+    .gallery { display: block; }
 
-    .photo-box {
-      width: 150px;
-      height: 120px;
-      border: 1px dashed #ccc;
-      border-radius: 4px;
+    .gallery-main {
+      width: 100%;
+      height: 440px;
+      border: 1px solid #e8e8e8;
+      border-radius: 6px;
+      background: #fafaf8;
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 12px;
+      overflow: hidden;
+      cursor: zoom-in;
+    }
+
+    .gallery-main img {
+      max-width: 100%;
+      max-height: 100%;
+      object-fit: contain;
+      display: block;
+    }
+
+    .gallery-main .no-image {
+      font-size: 13px;
       color: #aaa;
+    }
+
+    .gallery-thumbs {
+      display: flex;
+      gap: 8px;
+      margin-top: 12px;
+      flex-wrap: wrap;
+    }
+
+    .gallery-thumb {
+      width: 72px;
+      height: 72px;
+      border: 1px solid #e8e8e8;
+      border-radius: 4px;
       background: #fafaf8;
+      overflow: hidden;
+      cursor: pointer;
+      padding: 0;
+      transition: border-color 0.12s;
+    }
+
+    .gallery-thumb img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    .gallery-thumb:hover { border-color: #888; }
+    .gallery-thumb.active { border-color: #1a1a1a; border-width: 2px; }
+
+    .lightbox-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.85);
+      z-index: 300;
+      align-items: center;
+      justify-content: center;
+      cursor: zoom-out;
+    }
+
+    .lightbox-overlay.active { display: flex; }
+
+    .lightbox-overlay img {
+      max-width: 92vw;
+      max-height: 92vh;
+      object-fit: contain;
+    }
+
+    .lightbox-close {
+      position: absolute;
+      top: 16px;
+      right: 20px;
+      color: white;
+      background: none;
+      border: none;
+      font-size: 28px;
+      cursor: pointer;
+      line-height: 1;
     }
 
     .listing-title {
@@ -179,9 +248,43 @@
   </div>
 </div>
 
+<!-- Lightbox for fullsize gallery image -->
+<div class="lightbox-overlay" id="lightboxOverlay" onclick="closeLightbox(event)">
+  <button type="button" class="lightbox-close" onclick="closeLightbox(event)">&times;</button>
+  <img id="lightboxImg" src="" alt="">
+</div>
+
 <footer>Switchr &mdash; Sprint 3 &mdash; CSE 4214</footer>
 
 <script>
+  // gallery interaction
+  function setGalleryImage(index) {
+    var photos = window.__galleryPhotos || [];
+    if (!photos[index]) return;
+    var mainImg = document.getElementById('galleryMainImg');
+    if (mainImg) mainImg.src = photos[index];
+    document.querySelectorAll('#galleryThumbs .gallery-thumb').forEach(function(t) {
+      t.classList.toggle('active', parseInt(t.getAttribute('data-index')) === index);
+    });
+  }
+
+  function openLightbox() {
+    var mainImg = document.getElementById('galleryMainImg');
+    if (!mainImg) return;
+    document.getElementById('lightboxImg').src = mainImg.src;
+    document.getElementById('lightboxOverlay').classList.add('active');
+  }
+
+  function closeLightbox(event) {
+    // ignore clicks that bubbled up from the image itself
+    if (event && event.target.tagName === 'IMG') return;
+    document.getElementById('lightboxOverlay').classList.remove('active');
+  }
+
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') closeLightbox();
+  });
+
   // auth header
   var authLinks = document.getElementById('authLinks');
   if (isLoggedIn()) {
@@ -227,28 +330,45 @@
 
     var html = '<div class="listing-left">';
 
+    var photos = (l.photo_urls && l.photo_urls.length) ? l.photo_urls : [];
+
     html += '<div class="card">';
-    html += '<div class="photo-placeholder">';
-    html += '<div class="photo-box">' + (l.photo_urls && l.photo_urls[0] ? '<img src="' + l.photo_urls[0] + '" style="width:100%;height:100%;object-fit:cover;border-radius:6px;">' : 'No Image') + '</div>';
-    html += '<div class="photo-box">' + (l.photo_urls && l.photo_urls[1] ? '<img src="' + l.photo_urls[1] + '" style="width:100%;height:100%;object-fit:cover;border-radius:6px;">' : '') + '</div>';
-    html += '<div class="photo-box">' + (l.photo_urls && l.photo_urls[2] ? '<img src="' + l.photo_urls[2] + '" style="width:100%;height:100%;object-fit:cover;border-radius:6px;">' : '') + '</div>';
+    html += '<div class="gallery">';
+    if (photos.length === 0) {
+      html += '<div class="gallery-main"><span class="no-image">No Image</span></div>';
+    } else {
+      html += '<div class="gallery-main" id="galleryMain" onclick="openLightbox()">';
+      html += '<img id="galleryMainImg" src="' + photos[0] + '" alt="' + (l.title || 'Listing photo') + '">';
+      html += '</div>';
+      if (photos.length > 1) {
+        html += '<div class="gallery-thumbs" id="galleryThumbs">';
+        photos.forEach(function(url, i) {
+          html += '<button type="button" class="gallery-thumb' + (i === 0 ? ' active' : '') + '" '
+               +  'data-index="' + i + '" onclick="setGalleryImage(' + i + ')">'
+               +  '<img src="' + url + '" alt="">'
+               +  '</button>';
+        });
+        html += '</div>';
+      }
+    }
     html += '</div>';
     html += '</div>';
 
     html += '<div class="card">';
     html += '<h1 class="listing-title">' + l.title + '</h1>';
     html += '<p class="seller-info">Listed by <strong>' + l.seller_username + '</strong> &middot; ' + (l.created_at || '') + '</p>';
+    html += '<h3 style="margin-bottom:8px;">Description</h3>';
+    html += '<p style="font-size:14px; line-height:1.6; color:#444; margin-bottom:0;">' + l.description + '</p>';
+    html += '</div>';
 
+    html += '<div class="card">';
     html += '<div class="detail-row"><span class="detail-label">Category</span><span class="detail-value">' + l.category + '</span></div>';
     html += '<div class="detail-row"><span class="detail-label">Condition</span><span class="detail-value">' + l.condition + '</span></div>';
     html += '<div class="detail-row"><span class="detail-label">Listing Type</span><span class="detail-value"><span class="badge ' + typeClass + '">' + typeLabel + '</span></span></div>';
     html += '<div class="detail-row"><span class="detail-label">Status</span><span class="detail-value">' + l.status + '</span></div>';
     html += '</div>';
 
-    html += '<div class="card">';
-    html += '<h3>Description</h3>';
-    html += '<p style="font-size:14px; line-height:1.6; color:#444;">' + l.description + '</p>';
-    html += '</div>';
+    window.__galleryPhotos = photos;
 
     html += '</div>'; // end listing-left
 

--- a/frontend/pages/seller/create-listing.html
+++ b/frontend/pages/seller/create-listing.html
@@ -284,11 +284,38 @@
 
   function submitListing() {
     var btn = document.getElementById('submitBtn');
+
+    var title = document.getElementById('title').value.trim();
+    var description = document.getElementById('description').value.trim();
+    var category = document.getElementById('category').value;
+    var condition = document.getElementById('condition').value;
+    var listingType = document.getElementById('listingType').value;
+    var quantity = document.getElementById('quantity').value;
+
+    var missing = [];
+    if (!title) missing.push('Title');
+    if (!description) missing.push('Description');
+    if (!category) missing.push('Category');
+    if (!condition) missing.push('Condition');
+    if (!listingType) missing.push('Listing Type');
+    if (!quantity) missing.push('Quantity');
+
+    if (listingType === 'AUCTION') {
+      if (!document.getElementById('starting_price').value) missing.push('Starting Price');
+      if (!document.getElementById('auction_duration_days').value) missing.push('Auction Duration');
+    } else if (listingType && listingType !== 'TRADE') {
+      if (!document.getElementById('price').value) missing.push('Price');
+    }
+
+    if (missing.length) {
+      showError('Please fill in: ' + missing.join(', '));
+      return;
+    }
+
     btn.disabled = true;
     btn.textContent = 'Submitting...';
 
     var formData = new FormData();
-    var listingType = document.getElementById('listingType').value;
     formData.append('title', document.getElementById('title').value.trim());
     formData.append('description', document.getElementById('description').value.trim());
     formData.append('category', document.getElementById('category').value);

--- a/frontend/pages/seller/create-listing.html
+++ b/frontend/pages/seller/create-listing.html
@@ -283,6 +283,10 @@
   }
 
   function submitListing() {
+    var btn = document.getElementById('submitBtn');
+    btn.disabled = true;
+    btn.textContent = 'Submitting...';
+
     var formData = new FormData();
     var listingType = document.getElementById('listingType').value;
     formData.append('title', document.getElementById('title').value.trim());
@@ -318,6 +322,8 @@
             window.location.href = '/pages/seller/dashboard.html';
         } else {
             alert(data.error || 'Something went wrong.');
+            btn.disabled = false;
+            btn.textContent = 'Submit Listing';
         }
     })
     .catch(function() {


### PR DESCRIPTION
## Summary
- New `password_resets` table (token, expires_at, used_at) and two endpoints: `POST /api/auth/forgot-password` and `POST /api/auth/reset-password`
- New `forgot-password.html` and `reset-password.html` pages, login link wired up
- Tokens are `uuid4().hex`, expire in 1 hour, and are single-use; reset link is returned in the API response in dev mode so the flow works without SMTP

## Test plan
- [ ] Login page → "Forgot your password?" navigates to forgot-password page
- [ ] Submitting an unknown email returns the same generic success (no enumeration)
- [ ] Submitting a known email shows the dev-mode reset link inline
- [ ] Reset link opens reset-password page with token in URL
- [ ] Mismatched passwords show inline error; matching passwords < 6 chars rejected by backend
- [ ] After reset, old password is rejected and new password logs in
- [ ] Reusing the same reset token returns "Invalid or expired reset link"