### PR TITLE
Fix deny-user endpoint when frontend sends empty body

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -856,8 +856,8 @@ def approve_user(user_id):
 @app.route('/api/admin/users/<int:user_id>/deny', methods=['PUT'])
 @admin_required
 def deny_user(user_id):
-    data = request.get_json() or {}
-    reason = data.get('reason', '').strip()
+    data = request.get_json(silent=True) or {}
+    reason = (data.get('reason') or '').strip()
 
     try:
         conn = get_db()


### PR DESCRIPTION
deny_user called request.get_json() without silent=True. The admin dashboard's deny button sends a PUT with Content-Type: application/json but no body, which Flask treated as a malformed request and rejected with 400 before any of the deny logic ran. Use silent=True with an empty-dict fallback so the optional reason field stays optional.