### PR TITLE
Don't auto-log-in users after registration

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -430,9 +430,10 @@ def register():
         user = cur.fetchone()
         conn.close()
 
-        token = generate_token(user)
+        # Do NOT issue a JWT here. New accounts are 'pending' and must wait for
+        # admin approval before they can sign in. Returning a token would let
+        # them bypass the pending gate just by refreshing the page.
         return jsonify({
-            'token': token,
             'user': {
                 'id': user['id'],
                 'email': user['email'],

--- a/frontend/js/auth.js
+++ b/frontend/js/auth.js
@@ -90,8 +90,13 @@ async function register(email, username, password) {
     const data = await response.json();
 
     if (response.ok) {
-        setToken(data.token);
-        setUser(data.user);
+        // New accounts are pending admin approval. The backend deliberately
+        // does NOT return a token here, so we don't store one — the user has
+        // to log in after they've been approved.
+        if (data.token) {
+            setToken(data.token);
+            setUser(data.user);
+        }
         return { success: true, user: data.user };
     } else {
         return { success: false, error: data.error };


### PR DESCRIPTION
Registration was returning a JWT and the frontend was caching it in localStorage. Refreshing the register page (or any page that calls redirectIfLoggedIn) would then bypass the "account pending admin approval" gate because a token was already present. New accounts are always created with status='pending', so issuing a session token at this point is wrong — the user must wait for admin approval and then sign in. Backend now omits the token from the register response; frontend tolerates either shape and only stores credentials when a token is actually present.